### PR TITLE
The use of the word 'master' can be exclusionary

### DIFF
--- a/styleguide/bias-free-communication.md
+++ b/styleguide/bias-free-communication.md
@@ -84,7 +84,7 @@ countries with states or continents.
 
 |    **Use this**    |       **Not this**       |
 |--------------------|--------------------------|
-| master/subordinate |       master/slave       |
+| primary/replica |       master/slave       |
 | perimeter network  | demilitarized zone (DMZ) |
 |  stop responding   |           hang           |
 


### PR DESCRIPTION
In the case of the standard writing of 'master/slave', it should be rewritten to 'primary/replica'.