### PR TITLE
Fix rendering of the 'Examples' table

### DIFF
--- a/styleguide/punctuation/dashes-hyphens/hyphens.md
+++ b/styleguide/punctuation/dashes-hyphens/hyphens.md
@@ -137,6 +137,7 @@ For more information about using prefixes, see [*The Chicago Manual of Style*](h
 Capitalize any part of a hyphenated compound word that would be capitalized if there were no hyphen. 
 
 **Examples**  
+
 | Compound word       | Example sentence |
 | ------------- |-------------|
 | Customer-friendly | Customer-friendly content is brief, accurate, and to the point.|


### PR DESCRIPTION
**Minor Fix:** The table doesn't render correctly on https://docs.microsoft.com/en-us/style-guide/punctuation/dashes-hyphens/hyphens due to missing whitespace after the title. I've added the necessary whitespace.