### PR TITLE
Unbiased title

### DIFF
--- a/styleguide/bias-free-communication.md
+++ b/styleguide/bias-free-communication.md
@@ -1,5 +1,5 @@
 ---
-title: Bias-free communication - Microsoft Style Guide
+title: Unbiased communication - Microsoft Style Guide
 author: pallep
 ms.author: pallep
 ms.date: 09/13/2019


### PR DESCRIPTION
The page points out:

> **Don't use terms that may carry unconscious racial bias or terms associated with military actions, politics, or historical events and eras.**

Examples given on the page suggests to use "_primary/subordinate_" instead of "_master/slave_", and "_stop responding_" instead of "_hang_".

However, the title itself: "Bias-**free** communication" has an unconscious military action / privilege associated with it, whereby, "_free_" could be perceived as "_free_ as in _freedom of a nation_", or "_free_ as in _freeing a slave_".

Should not the title, and the file name itself, be changed to something more neutral like "**Unbiased** communication".

I realize that this might be excessive overthinking, but an article pointing out a rule should itself follow that rule.

Also, introducing a hyphen in title / heading is inconsistent considering that file / folder names use hyphens for word separation. An automatic tool that parses file names would produce an output of "Bias free communication" instead of the expected "Bias-free communication".

**Note:** I only edited the heading in file; in case, this pull request is accepted, the file name should be changed as well.